### PR TITLE
[hotfix] entity default 값 설정

### DIFF
--- a/src/main/java/com/example/oss_project/domain/entity/AdSlot.java
+++ b/src/main/java/com/example/oss_project/domain/entity/AdSlot.java
@@ -28,9 +28,10 @@ public class AdSlot {
     @JoinColumn(name = "admin_id")
     private Admin admin;
 
+    @Builder.Default
     @Enumerated(EnumType.STRING)
     @Column(name = "ad_slot_status")
-    private AdSlotStatus adSlotStatus;
+    private AdSlotStatus adSlotStatus = AdSlotStatus.BEFORE_BIDDING;
 
     @Column(name = "ad_slot_name")
     private String adSlotName;

--- a/src/main/java/com/example/oss_project/domain/entity/BidHistory.java
+++ b/src/main/java/com/example/oss_project/domain/entity/BidHistory.java
@@ -46,9 +46,10 @@ public class BidHistory extends BaseEntity {
     @Column(name = "bid_money",nullable = false)
     private Long bidMoney;
 
+    @Builder.Default
     @Enumerated(EnumType.STRING)
     @Column(name = "bid_status",nullable = false)
-    private BidStatus bidStatus;
+    private BidStatus bidStatus = BidStatus.BEFORE_BIDDING;
 
     @Column(name = "bid_start_time")
     private LocalDateTime bidStartTime;


### PR DESCRIPTION
## #️⃣연관된 이슈

#41 hotfix 이슈

## 📝작업 내용
엔티티 BidStatus, adSlotStatus에 Default값을 각각 BEFORE_BIDDING으로 설정