### PR TITLE
[hotfix] adslot setBidTime 현재 시간으로 설정

### DIFF
--- a/src/main/java/com/example/oss_project/domain/entity/AdSlot.java
+++ b/src/main/java/com/example/oss_project/domain/entity/AdSlot.java
@@ -74,8 +74,8 @@ public class AdSlot {
 
 
     public void setBidTime() {
-        //LocalDateTime now = LocalDateTime.now();
-        LocalDateTime now = LocalDateTime.of(2025, 6, 1, 8, 0); // 2025년 6월 2일 12:00로 고정
+        LocalDateTime now = LocalDateTime.now();
+        //LocalDateTime now = LocalDateTime.of(2025, 6, 1, 8, 0); // 2025년 6월 2일 12:00로 고정
         LocalDate tomorrow = now.toLocalDate().plusDays(1);
 
         this.bidStartTime = LocalDateTime.of(tomorrow, LocalTime.MIDNIGHT); // 내일 00:00


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #41 

## 📝작업 내용

> 실제 로직 테스트를 위한 Bidtime을 now로 변경